### PR TITLE
Potential fix for code scanning alert no. 20: Prototype-polluting assignment

### DIFF
--- a/src/cjs/configHelper.cjs
+++ b/src/cjs/configHelper.cjs
@@ -30,10 +30,22 @@ function saveConfig(data) {
  * @param {any} value
  * @returns {void}
  */
-function checkConfigValue(key, value) {
-  const configs = getConfig();
+function isUnsafeKeySegment(segment) {
+  return segment === "__proto__" || segment === "prototype" || segment === "constructor";
+}
 
+function checkConfigValue(key, value) {
+  if (typeof key !== "string" || key.trim() === "") {
+    throw new Error("[checkConfigValue] key must be a non-empty string");
+  }
+
+  const configs = getConfig();
   const keys = key.split(".");
+
+  if (keys.some((segment) => !segment || isUnsafeKeySegment(segment))) {
+    throw new Error("[checkConfigValue] invalid or unsafe config key path");
+  }
+
   let current = configs;
 
   // percorre até a última chave


### PR DESCRIPTION
Potential fix for [https://github.com/LUISDASARTIMANHAS/npm-package-nodejs-utils-lda/security/code-scanning/20](https://github.com/LUISDASARTIMANHAS/npm-package-nodejs-utils-lda/security/code-scanning/20)

To fix prototype-polluting assignment safely without changing intended behavior, validate every path segment derived from `key` before using it as an object property. Reject dangerous property names (`"__proto__"`, `"prototype"`, `"constructor"`), and avoid proceeding when `key` is not a valid non-empty string. This preserves existing dot-path behavior while blocking prototype chain manipulation.

Best single fix in `src/cjs/configHelper.cjs`:
- Add a small denylist helper (for unsafe keys).
- In `checkConfigValue`, validate `key` type/emptiness.
- After `split(".")`, validate each segment against the denylist and emptiness.
- Abort (throw) on invalid/unsafe segments before any `current[...]` read/write.

This requires no new imports and no dependency changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
