### PR TITLE
Potential fix for code scanning alert no. 20: Prototype-polluting assignment

### DIFF
--- a/src/cjs/configHelper.cjs
+++ b/src/cjs/configHelper.cjs
@@ -52,9 +52,13 @@ function checkConfigValue(key, value) {
   for (let i = 0; i < keys.length - 1; i++) {
     const k = keys[i];
 
-    // se não existir, cria objeto
-    if (!current[k] || typeof current[k] !== "object") {
-      current[k] = {};
+    // se não existir ou não for objeto simples, cria objeto sem protótipo
+    if (
+      !current[k] ||
+      typeof current[k] !== "object" ||
+      Array.isArray(current[k])
+    ) {
+      current[k] = Object.create(null);
     }
 
     current = current[k];

--- a/src/cjs/configHelper.cjs
+++ b/src/cjs/configHelper.cjs
@@ -39,25 +39,32 @@ function checkConfigValue(key, value) {
     throw new Error("[checkConfigValue] key must be a non-empty string");
   }
 
-  const configs = getConfig();
+  const loadedConfig = getConfig();
   const keys = key.split(".");
 
   if (keys.some((segment) => !segment || isUnsafeKeySegment(segment))) {
     throw new Error("[checkConfigValue] invalid or unsafe config key path");
   }
 
-  let current = configs;
+  const safeConfigs = Object.create(null);
+  if (loadedConfig && typeof loadedConfig === "object" && !Array.isArray(loadedConfig)) {
+    Object.assign(safeConfigs, loadedConfig);
+  }
+
+  let current = safeConfigs;
 
   // percorre até a última chave
   for (let i = 0; i < keys.length - 1; i++) {
     const k = keys[i];
+    const next = current[k];
+    const isSafeObject =
+      next &&
+      typeof next === "object" &&
+      !Array.isArray(next) &&
+      (Object.getPrototypeOf(next) === null || Object.getPrototypeOf(next) === Object.prototype);
 
-    // se não existir ou não for objeto simples, cria objeto sem protótipo
-    if (
-      !current[k] ||
-      typeof current[k] !== "object" ||
-      Array.isArray(current[k])
-    ) {
+    // se não existir ou não for objeto simples/seguro, cria objeto sem protótipo
+    if (!isSafeObject) {
       current[k] = Object.create(null);
     }
 
@@ -69,7 +76,7 @@ function checkConfigValue(key, value) {
   // só define se não existir
   if (current[lastKey] === undefined) {
     current[lastKey] = value;
-    saveConfig(configs);
+    saveConfig(safeConfigs);
   }
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/LUISDASARTIMANHAS/npm-package-nodejs-utils-lda/security/code-scanning/20](https://github.com/LUISDASARTIMANHAS/npm-package-nodejs-utils-lda/security/code-scanning/20)

Use **prototype-less objects** for all intermediate containers created during path traversal, and ensure traversal only continues through plain object-like nodes (not arrays/functions/etc.). This preserves functionality (nested config set-if-missing) while eliminating inherited prototype behavior on created nodes.

Best targeted fix in `src/cjs/configHelper.cjs`:
- In `checkConfigValue`, replace `current[k] = {}` with `current[k] = Object.create(null)`.
- Tighten the “object exists” check so traversal only reuses safe object containers.
- Keep existing unsafe-segment validation as a defense-in-depth layer.

No import changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
