### PR TITLE
Potential fix for code scanning alert no. 18: Prototype-polluting function

### DIFF
--- a/src/esm/configHelper.mjs
+++ b/src/esm/configHelper.mjs
@@ -32,12 +32,20 @@ export function saveConfig(data) {
 export function checkConfigValue(key, value) {
   const configs = getConfig();
 
+  const blockedKeys = new Set(["__proto__", "constructor", "prototype"]);
+  const isUnsafeKey = (k) => blockedKeys.has(k);
+
   const keys = key.split(".");
   let current = configs;
 
   // percorre até a última chave
   for (let i = 0; i < keys.length - 1; i++) {
     const k = keys[i];
+
+    if (isUnsafeKey(k)) {
+      console.warn(`[checkConfigValue] unsafe key blocked: ${k}`);
+      return;
+    }
 
     // se não existir, cria objeto
     if (!current[k] || typeof current[k] !== "object") {
@@ -48,6 +56,11 @@ export function checkConfigValue(key, value) {
   }
 
   const lastKey = keys[keys.length - 1];
+
+  if (isUnsafeKey(lastKey)) {
+    console.warn(`[checkConfigValue] unsafe key blocked: ${lastKey}`);
+    return;
+  }
 
   // só define se não existir
   if (current[lastKey] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/LUISDASARTIMANHAS/npm-package-nodejs-utils-lda/security/code-scanning/18](https://github.com/LUISDASARTIMANHAS/npm-package-nodejs-utils-lda/security/code-scanning/18)

To fix this safely without changing intended functionality, validate each path segment before using it for traversal/assignment, and reject prototype-related keys. The best minimal fix is to block `__proto__`, `constructor`, and `prototype` in both the loop segments and final segment.

In `src/esm/configHelper.mjs`, inside `checkConfigValue`:
1. Add a small local guard (for example, a `Set` of blocked keys + helper function).
2. In the traversal loop, if a segment is blocked, abort (or throw).
3. Before assigning `current[lastKey]`, apply the same guard.
4. Keep existing behavior for normal keys unchanged.

This addresses the CodeQL finding at its source (deep assignment) and preserves current config write logic.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
