### PR TITLE
Potential fix for code scanning alert no. 6: Overly permissive regular expression range

### DIFF
--- a/src/cjs/utils.cjs
+++ b/src/cjs/utils.cjs
@@ -232,7 +232,7 @@ function fileExistAndCreate(filePath, defaultContent = []) {
 function sanitizeInput(input) {
   if (typeof input !== "string") throw new Error("Input must be a string");
   // permite apenas letras, números, pontos, hífens e dois-pontos (para IPs)
-  const sanitized = input.replace(/[^a-zA-Z0-9.-:]/g, "");
+  const sanitized = input.replace(/[^a-zA-Z0-9.:-]/g, "");
   if (!sanitized) throw new Error("Invalid input after sanitization");
   return sanitized;
 }


### PR DESCRIPTION
Potential fix for [https://github.com/LUISDASARTIMANHAS/npm-package-nodejs-utils-lda/security/code-scanning/6](https://github.com/LUISDASARTIMANHAS/npm-package-nodejs-utils-lda/security/code-scanning/6)

A correção é tornar o hífen literal dentro da classe de caracteres, evitando que ele crie intervalo.  
A melhor forma sem alterar funcionalidade pretendida é ajustar apenas a regex na função `sanitizeInput` em `src/cjs/utils.cjs`, linha da definição de `sanitized`:

- De: `input.replace(/[^a-zA-Z0-9.-:]/g, "")`
- Para: `input.replace(/[^a-zA-Z0-9.:-]/g, "")` (hífen no final, literal)

Alternativamente, `\ -` escapado também funcionaria, mas mover para o fim mantém legibilidade e elimina ambiguidade.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
