### PR TITLE
Potential fix for code scanning alert no. 26: Prototype-polluting function

### DIFF
--- a/src/cjs/configHelper.cjs
+++ b/src/cjs/configHelper.cjs
@@ -56,15 +56,16 @@ function checkConfigValue(key, value) {
   // percorre até a última chave
   for (let i = 0; i < keys.length - 1; i++) {
     const k = keys[i];
-    const next = current[k];
+    const hasOwn = Object.prototype.hasOwnProperty.call(current, k);
+    const next = hasOwn ? current[k] : undefined;
     const isSafeObject =
       next &&
       typeof next === "object" &&
       !Array.isArray(next) &&
       (Object.getPrototypeOf(next) === null || Object.getPrototypeOf(next) === Object.prototype);
 
-    // se não existir ou não for objeto simples/seguro, cria objeto sem protótipo
-    if (!isSafeObject) {
+    // só faz merge recursivo em propriedade própria e objeto seguro; caso contrário cria objeto sem protótipo
+    if (!hasOwn || !isSafeObject) {
       current[k] = Object.create(null);
     }
 
@@ -73,8 +74,11 @@ function checkConfigValue(key, value) {
 
   const lastKey = keys[keys.length - 1];
 
-  // só define se não existir
-  if (current[lastKey] === undefined) {
+  // só define se não existir como propriedade própria ou se estiver undefined
+  if (
+    !Object.prototype.hasOwnProperty.call(current, lastKey) ||
+    current[lastKey] === undefined
+  ) {
     current[lastKey] = value;
     saveConfig(safeConfigs);
   }


### PR DESCRIPTION
Potential fix for [https://github.com/LUISDASARTIMANHAS/npm-package-nodejs-utils-lda/security/code-scanning/26](https://github.com/LUISDASARTIMANHAS/npm-package-nodejs-utils-lda/security/code-scanning/26)

Use a strict own-property guard before recursive traversal and final assignment, so path writes only happen through properties that already belong to the current destination object. This is the safest way to satisfy the prototype-pollution rule and preserve existing behavior of “set only if undefined”.

In `src/cjs/configHelper.cjs`, inside `checkConfigValue`:
1. In the traversal loop, only recurse into `current[k]` when `k` is an own property and is a safe object; otherwise initialize `current[k]` as a null-prototype object.
2. At final write, assign only when `lastKey` is an own property with `undefined` value, or when it does not exist as an own property (same effective behavior as now, but explicit own-property based check).

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
