### PR TITLE
Potential fix for code scanning alert no. 18: Prototype-polluting function

### DIFF
--- a/src/esm/configHelper.mjs
+++ b/src/esm/configHelper.mjs
@@ -74,6 +74,11 @@ export function checkConfigValue(key, value) {
     return;
   }
 
+  // defesa em profundidade no sink: nunca grava em alvo inseguro
+  if (isUnsafeKey(lastKey) || !hasOwn(Object(current), lastKey) && !isPlainObject(current)) {
+    return;
+  }
+
   // só define se não existir como propriedade própria
   if (!hasOwn(current, lastKey)) {
     current[lastKey] = value;


### PR DESCRIPTION
Potential fix for [https://github.com/LUISDASARTIMANHAS/npm-package-nodejs-utils-lda/security/code-scanning/18](https://github.com/LUISDASARTIMANHAS/npm-package-nodejs-utils-lda/security/code-scanning/18)

To fix this class of issue, ensure deep assignment never writes through an object that could resolve via prototype chain or special keys. In this file, the best minimal fix is to add a strict guard right before line 79 so the final target object (`current`) is guaranteed to be a plain object with safe own-property semantics, and to avoid assignment on potentially tainted inherited targets.

**Best concrete change in `src/esm/configHelper.mjs`:**
1. Keep existing key-segment blocking (`__proto__`, `constructor`, `prototype`).
2. Strengthen the final assignment block by requiring `current` to be a plain object and rejecting assignment if `lastKey` is unsafe (defense-in-depth at sink).
3. Only assign when `lastKey` is not already own, as already intended.

No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
